### PR TITLE
LP: added cluster link in RecoParticle branch

### DIFF
--- a/include/LCTuple.h
+++ b/include/LCTuple.h
@@ -10,6 +10,7 @@
 #include "JetBranches.h"
 #include "TrackBranches.h"
 #include "PIDBranches.h"
+#include "RecoParticleBranches.h"
 
 
 using namespace lcio ;
@@ -129,7 +130,7 @@ class LCTuple : public Processor {
   CWBranchesSet* _evtBranches {};
   CollectionBranches* _mcpBranches {};
   CollectionBranches* _mcpremoveoverlayBranches {};
-  CollectionBranches* _recBranches {};
+  RecoParticleBranches* _recBranches {};
 //  CollectionBranches* _jetBranches {};
   JetBranches* _jetBranches {};
   CollectionBranches* _isolepBranches {};

--- a/include/RecoParticleBranches.h
+++ b/include/RecoParticleBranches.h
@@ -27,7 +27,7 @@ public:
   
   virtual void initBranches( TTree* tree, const std::string& prefix="" ) ; //const char*  prefix=0) ;
   
-  virtual void fill(const EVENT::LCCollection* col, EVENT::LCEvent* evt ) ;
+  virtual void fill(const EVENT::LCCollection* col, EVENT::LCEvent* evt, const EVENT::LCCollection* colCluster ) ;
   
   virtual ~RecoParticleBranches() {} ;
   
@@ -71,6 +71,7 @@ private:
   // EVENT::ClusterVec _clusters ;
   // EVENT::TrackVec _tracks ;
   
+  int    _rcclid[ LCT_RECOPARTICLE_MAX ][10]  {} ;
   
 } ;
 

--- a/src/LCTuple.cc
+++ b/src/LCTuple.cc
@@ -565,7 +565,7 @@ void LCTuple::processEvent( LCEvent * evt ) {
   if( mcpRemoveOverlayCol ) _mcpremoveoverlayBranches->fill( mcpRemoveOverlayCol , evt ) ;
 
   if( recCol ) {
-    _recBranches->fill( recCol , evt ) ;
+    _recBranches->fill( recCol , evt , cluCol ) ;
 
     for( auto pidb : _pidBranchesVec ) pidb->fill( recCol , evt ) ;
   }

--- a/src/RecoParticleBranches.cc
+++ b/src/RecoParticleBranches.cc
@@ -7,6 +7,7 @@
 #include "EVENT/Vertex.h"
 
 #include "TTree.h"
+#include <algorithm>
 
 
 void RecoParticleBranches::initBranches( TTree* tree, const std::string& pre){
@@ -54,10 +55,12 @@ void RecoParticleBranches::initBranches( TTree* tree, const std::string& pre){
   tree->Branch( (pre+"pillh").c_str() , _pillh , (pre+"pillh["+pre+"npid]/F").c_str() ) ;
   tree->Branch( (pre+"pialg").c_str() , _pialg , (pre+"pialg["+pre+"npid]/I").c_str() ) ;
   
+  //tree->Branch( (pre+"rcclid").c_str() , _rcclid , (pre+"rcclid["+pre+"nrec]["+pre+"rcncl]/I").c_str() ) ;
+  tree->Branch( (pre+"rcclid").c_str() , _rcclid , (pre+"rcclid["+pre+"nrec][10]/I").c_str() ) ;
 }
   
 
-void RecoParticleBranches::fill(const EVENT::LCCollection* col, EVENT::LCEvent* evt ){
+void RecoParticleBranches::fill(const EVENT::LCCollection* col, EVENT::LCEvent* evt, const EVENT::LCCollection* colCluster){
   
   if( !col ) return ;
 
@@ -104,7 +107,7 @@ void RecoParticleBranches::fill(const EVENT::LCCollection* col, EVENT::LCEvent* 
     _pialg[ i ] = pid->getAlgorithmType() ;
   }
 
-
+  std::vector<int> usedClusters;
 
   //------  fill the Reconstructed particle ----------------------------
   for(int i=0 ; i < _nrec ; ++i){
@@ -146,7 +149,33 @@ void RecoParticleBranches::fill(const EVENT::LCCollection* col, EVENT::LCEvent* 
     _rcnrp[ i ] = rec->getParticles().size();
 
     _rcftr[ i ] = ( rec->getTracks().size() > 0 ?  rec->getTracks()[0]->ext<CollIndex>() - 1  :  -1 )   ;
+
+    for(int s = 0; s < 10; s++){
+      _rcclid[i][s] = -1;
+    }
     
+    if(!colCluster) continue;
+    lcio::ClusterVec clusters = rec->getClusters();
+    lcio::Cluster* temp_clus = NULL;
+
+    for(unsigned int c = 0; c < clusters.size(); c++){
+
+      for(int ccoll = 0; ccoll < colCluster->getNumberOfElements(); ccoll++){
+
+        if(std::find(usedClusters.begin(), usedClusters.end(), ccoll) != usedClusters.end() )
+          continue;
+
+        temp_clus = static_cast<lcio::Cluster*>( colCluster->getElementAt(ccoll) );
+        
+        if(temp_clus->id() != clusters[c]->id()) continue;
+
+        _rcclid[i][c] = ccoll;
+        usedClusters.push_back(ccoll);
+        break;
+      }
+    }
+
+    usedClusters.clear();
   }
 
 }


### PR DESCRIPTION

The RecoParticleBranch now contains a new entry "rcclid", which contains the indices of the recoparticle's clusters in the corresponding ClusterBranch. If no cluster collection is provided, the entry is left empty.